### PR TITLE
IP2Location object can be closed and can be used as Context Manager

### DIFF
--- a/IP2Location.py
+++ b/IP2Location.py
@@ -94,8 +94,19 @@ class IP2Location(object):
         if filename:
             self.open(filename)
 
+    def __enter__(self):
+        if not hasattr(self, '_f') or self._f.closed:
+            raise ValueError("Cannot enter context with closed file")
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
     def open(self, filename):
         ''' Opens a database file '''
+        # Ensure old file is closed before oppening a new one
+        self.close()
+
         self._f = open(filename, 'rb')
         self._dbtype = struct.unpack('B', self._f.read(1))[0]
         self._dbcolumn = struct.unpack('B', self._f.read(1))[0]
@@ -106,6 +117,12 @@ class IP2Location(object):
         self._ipv4dbaddr = struct.unpack('<I', self._f.read(4))[0]
         self._ipv6dbcount = struct.unpack('<I', self._f.read(4))[0]
         self._ipv6dbaddr = struct.unpack('<I', self._f.read(4))[0]
+
+    def close(self):
+        if hasattr(self, '_f'):
+            # If there is file close it.
+            self._f.close()
+            del self._f
 
     def get_country_short(self, ip):
         ''' Get country_short '''

--- a/test.py
+++ b/test.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; If not, see <http://www.gnu.org/licenses/>.
+from __future__ import with_statement
 
 import os
 import sys
@@ -51,6 +52,37 @@ for line in open(os.path.join("data", "country_test_ipv6_data.txt")):
                     % (addr, test_num, rec and rec.country_short or 'None', country_short))
         else:
             passed += 1
+
+test_num += 1
+try:
+    database.close()
+except:
+    failed += 1
+    print("Test DB closing (Test %d) failed." % (test_num))
+else:
+    passed += 1
+
+test_num += 1
+try:
+    with database:
+        pass
+except ValueError:
+    passed += 1
+else:
+    failed += 1
+    print("Test 'with' statement with closed db failed (Test %d)" % (test_num))
+
+
+test_num += 1
+try:
+    with IP2Location.IP2Location(os.path.join("data", "IP-COUNTRY.BIN")) as db:
+        rec = db.get_all('19.5.10.1')
+except:
+    failed += 1
+    print("Test With statement failed (Test %d)" % (test_num))
+    raise
+else:
+    passed += 1
 
 print('PASS: %d' % (passed))
 print('FAIL: %d' % (failed))


### PR DESCRIPTION
1. Add method `close` to `IP2Location` object to close the database file
2. Ensure that old DB file is closed before opening a new one
3. Make it possible to use `IP2Location` objects as context managers

Running the test now require Python 2.5 because of `from __future__ import with_statement`. If this is not desirable I can remove the test for `with` statement.
